### PR TITLE
Fix bit shifting

### DIFF
--- a/old/pysearch.cpp
+++ b/old/pysearch.cpp
@@ -277,7 +277,7 @@ void find_expressions(int n) {
           z = 0*oL; z[oL <= oR] = 1;
           cache_if_better(cn, z, Expr{&eL, &eR, Operator::Leq, 0, mask});
         }
-        if (eL.prec() > 9 && eR.prec() >= 9 && (oR >= 0).min() && (oR <= 31).min()) {
+        if (eL.prec() >= 9 && eR.prec() > 9 && (oR >= 0).min() && (oR <= 31).min()) {
           if (Use_BitShl) cache_if_better(cn, oL << oR, Expr{&eL, &eR, Operator::BitShl, 0, mask});
           if (Use_BitShr) cache_if_better(cn, oL >> oR, Expr{&eL, &eR, Operator::BitShr, 0, mask});
         }

--- a/src/main.rs
+++ b/src/main.rs
@@ -232,7 +232,7 @@ fn find_expressions(mut_cache: &mut Cache, n: usize) {
                                 cache,
                             );
                         }
-                        if el.prec() > 9 && er.prec() >= 9 && vec_in(or, 0..=31) {
+                        if el.prec() >= 9 && er.prec() > 9 && vec_in(or, 0..=31) {
                             if USE_BIT_SHL {
                                 save(
                                     &mut cn,


### PR DESCRIPTION
`eL.prec() > 9 && eR.prec() >= 9`  should be `eL.prec() >= 9 && eR.prec() > 9`.
Because `(a<<b)<<c == a<<b<<c != a<<(b<<c)`