### PR TITLE
Use hashbrown HashMap

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,17 @@
 version = 3
 
 [[package]]
+name = "ahash"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c99f64d1e06488f620f932677e24bc6e2897582980441ae90a671415bd7ec2f"
+dependencies = [
+ "cfg-if",
+ "once_cell",
+ "version_check",
+]
+
+[[package]]
 name = "autocfg"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -64,6 +75,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7fcaabb2fef8c910e7f4c7ce9f67a1283a1715879a7c230ca9d6d1ae31f16d91"
 
 [[package]]
+name = "hashbrown"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43a3c133739dddd0d2990f9a4bdf8eb4b21ef50e4851ca85ab661199821d510e"
+dependencies = [
+ "ahash",
+ "rayon",
+]
+
+[[package]]
 name = "hermit-abi"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -98,9 +119,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "once_cell"
+version = "1.17.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7e5500299e16ebb147ae15a00a942af264cf3688f47923b8fc2cd5858f23ad3"
+
+[[package]]
 name = "pysearch"
 version = "0.1.0"
 dependencies = [
+ "hashbrown",
  "rayon",
 ]
 
@@ -131,3 +159,9 @@ name = "scopeguard"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
+
+[[package]]
+name = "version_check"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,9 +10,11 @@ overflow-checks = false
 
 [features]
 simd = []
+rayon = ["dep:rayon", "hashbrown/rayon"]
 
 [dependencies]
 rayon = { version = "1.7.0", optional = true }
+hashbrown = "0.13.2"
 
 # Doesn't seem to help much:
 # [profile.release]

--- a/src/main.rs
+++ b/src/main.rs
@@ -17,8 +17,7 @@ use params::*;
 
 use vec::{divmod, vec_gcd, vec_in, vec_le, vec_lt, vec_or, vec_pow, Vector};
 
-use std::collections::hash_map::Entry;
-use std::collections::HashMap;
+use hashbrown::{hash_map::Entry, HashMap};
 use std::ptr::NonNull;
 use std::time::Instant;
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -356,13 +356,21 @@ fn find_variables_and_literals(cn: &mut CacheLevel, n: usize) {
 
 #[cfg(feature = "rayon")]
 fn find_expressions(mut_cache: &mut Cache, n: usize) {
-    use rayon::prelude::*;
+    use rayon::{iter::Either, prelude::*};
 
     let cache = &mut_cache;
     let mut cn = (1..n - 1)
         .into_par_iter()
         .flat_map(|k| {
-            cache[k].par_iter().map(move |r| {
+            // Use `par_bridge` for more parallelism when there're not enough
+            // items in the map.
+            // https://github.com/rust-lang/hashbrown/issues/383
+            if k <= 2 {
+                Either::Left(cache[k].iter().par_bridge())
+            } else {
+                Either::Right(cache[k].par_iter())
+            }
+            .map(move |r| {
                 let mut cn = CacheLevel::new();
                 find_binary_expressions(&mut cn, cache, n, k, r);
                 cn


### PR DESCRIPTION
While the map itself is the same as the one in std, it by default uses ahash, which is much faster and significantly speeds up single threaded pysearch, it also has built-in rayon support, which reduces peak memory usage by ~20% when rayon is enabled, but slightly slower.