### PR TITLE
DFS after MAX_CACHE_LENGTH

### DIFF
--- a/src/params.rs
+++ b/src/params.rs
@@ -30,6 +30,7 @@ pub fn match_goal(output: &Vector, _expr: &Expr) -> bool {
 pub const GOAL: &[Num] = &[1, -1, 0, 0];
 
 pub const MAX_LENGTH: usize = 14;
+pub const MAX_CACHE_LENGTH: usize = 10;
 pub const LITERALS: &[Num] = &[
     1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26,
     27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40,


### PR DESCRIPTION
Similar to @4atj's cpp fork https://github.com/4atj/pysearch_cpp

This allow us to put an upper limit on memory usage and search deeper without crash, it's also faster even if we have enough memory to cache everything, because building the cache for the last few levels takes a long time but it isn't being used that much.

Also included an optimization for commutative operators, which is more useful for `n > MAX_CACHE_LENGTH` because we no longer have a hashmap to dedup.