### PR TITLE
`USE_ALL_VARS` option && fixed `Expr::is_literal`

### DIFF
--- a/src/expr.rs
+++ b/src/expr.rs
@@ -42,7 +42,7 @@ impl Expr {
     }
 
     pub fn is_literal(&self) -> bool {
-        self.literal > 0
+        self.var_mask == 0
     }
 
     pub fn bin(el: NonNull<Expr>, er: NonNull<Expr>, op: Operator, var_mask: Mask) -> Self {

--- a/src/main.rs
+++ b/src/main.rs
@@ -34,8 +34,8 @@ fn positive_integer_length(mut k: Num) -> usize {
     l
 }
 
-fn can_use_required_vars(mask: u8, expr_length: usize) -> bool {
-    !USE_ALL_VARS || expr_length + (INPUTS.len() - (mask.count_ones() as usize)) * 2 <= MAX_LENGTH
+fn can_use_required_vars(mask: u8, length: usize) -> bool {
+    !USE_ALL_VARS || length + (INPUTS.len() - (mask.count_ones() as usize)) * 2 <= MAX_LENGTH
 }
 
 #[cfg(feature = "rayon")]
@@ -48,7 +48,9 @@ fn unit_if(b: bool) -> Option<()> {
 }
 
 fn save(level: &mut CacheLevel, output: Vector, expr: Expr, n: usize, cache: &Cache) {
-    if (expr.var_mask == ALL_MASK || !USE_ALL_VARS) && match_goal(&output, &expr) {
+    const ALL_MASK: Mask = (1 << INPUTS.len()) - 1;
+    
+    if (!USE_ALL_VARS || expr.var_mask == ALL_MASK) && match_goal(&output, &expr) {
         println!("{expr}");
         return;
     }
@@ -57,7 +59,6 @@ fn save(level: &mut CacheLevel, output: Vector, expr: Expr, n: usize, cache: &Ca
         return;
     }
     
-    const ALL_MASK: Mask = (1 << INPUTS.len()) - 1;
     if !REUSE_VARS && expr.var_mask == ALL_MASK {
         let mut mp: HashMap<Num, Num> = HashMap::new();
         for i in 0..GOAL.len() {

--- a/src/params.rs
+++ b/src/params.rs
@@ -62,3 +62,6 @@ pub const C_STYLE_MOD: bool = false;
 
 /// Search expressions that use the same variable twice (like `x*x`).
 pub const REUSE_VARS: bool = true;
+
+/// Controls whether all declared variables should be always used.
+pub const USE_ALL_VARS: bool = true;

--- a/src/params.rs
+++ b/src/params.rs
@@ -30,6 +30,7 @@ pub fn match_goal(output: &Vector, _expr: &Expr) -> bool {
 pub const GOAL: &[Num] = &[1, -1, 0, 0];
 
 pub const MAX_LENGTH: usize = 14;
+pub const MAX_CACHE_LENGTH: usize = 10;
 pub const LITERALS: &[Num] = &[
     1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26,
     27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40,


### PR DESCRIPTION
PR based on https://github.com/lynn/pysearch/pull/21 to avoid merge conflict, please merge that first <: