### PR TITLE
Place the output in the expression

### DIFF
--- a/src/expr.rs
+++ b/src/expr.rs
@@ -1,17 +1,21 @@
 use std::{fmt::Display, ptr::NonNull};
+use std::hash::{Hash, Hasher};
 
-use crate::{operator::Operator, params::INPUTS};
+use crate::{
+    vec::Vector,
+    operator::Operator,
+    params::{Num, INPUTS},
+};
 
-pub type Literal = i32;
 pub type Mask = u8;
 
-#[derive(Clone, Copy, Debug)]
+#[derive(Clone, Copy, Debug, Eq)]
 pub struct Expr {
     pub left: Option<NonNull<Expr>>,
     pub right: Option<NonNull<Expr>>,
-    pub literal: Literal,
     pub op: Operator,
     pub var_mask: Mask,
+    pub output: Vector
 }
 unsafe impl Send for Expr {}
 unsafe impl Sync for Expr {}
@@ -21,23 +25,23 @@ impl Expr {
         self.op as u8 >> 4
     }
 
-    pub fn variable(index: Literal) -> Self {
+    pub fn variable(index: usize) -> Self {
         Self {
             left: None,
             right: None,
-            op: Operator::Literal,
-            literal: !index,
+            op: Operator::Variable,
             var_mask: 1 << index,
+            output: Vector::from_slice(INPUTS[index].vec)
         }
     }
 
-    pub fn literal(value: Literal) -> Self {
+    pub fn literal(value: Num) -> Self {
         Self {
             left: None,
             right: None,
             op: Operator::Literal,
-            literal: value,
             var_mask: 0,
+            output: Vector::constant(value)
         }
     }
 
@@ -45,23 +49,23 @@ impl Expr {
         self.var_mask == 0
     }
 
-    pub fn bin(el: NonNull<Expr>, er: NonNull<Expr>, op: Operator, var_mask: Mask) -> Self {
+    pub fn bin(el: NonNull<Expr>, er: NonNull<Expr>, op: Operator, var_mask: Mask, output: Vector) -> Self {
         Self {
             left: Some(el),
             right: Some(er),
             op,
-            literal: 0,
             var_mask,
+            output
         }
     }
 
-    pub fn unary(er: NonNull<Expr>, op: Operator) -> Self {
+    pub fn unary(er: NonNull<Expr>, op: Operator, output: Vector) -> Self {
         Self {
             left: None,
             right: Some(er),
             op,
-            literal: 0,
             var_mask: unsafe { *er.as_ptr() }.var_mask,
+            output
         }
     }
 
@@ -70,8 +74,8 @@ impl Expr {
             left: None,
             right: Some(er),
             op: Operator::Parens,
-            literal: 0,
             var_mask: unsafe { *er.as_ptr() }.var_mask,
+            output: unsafe { *er.as_ptr() }.output
         }
     }
 }
@@ -87,19 +91,31 @@ impl Display for Expr {
             if self.op == Operator::Parens {
                 write!(f, ")")?;
             }
-        } else if self.literal < 0 {
-            write!(f, "{}", INPUTS[(!self.literal) as usize].name)?;
+        } else if self.op == Operator::Variable {
+            write!(f, "{}", INPUTS[self.var_mask.trailing_zeros() as usize].name)?;
         } else {
-            write!(f, "{}", self.literal)?;
+            write!(f, "{}", self.output[0])?;
         }
         Ok(())
+    }
+}
+
+impl Hash for Expr {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        self.output.hash(state);
+    }
+}
+
+impl PartialEq for Expr {
+    fn eq(&self, other: &Self) -> bool {
+        return self.output == other.output;
     }
 }
 
 // "3or" and ")or" are valid, but "nor" isn't.
 pub fn ok_before_keyword(e: &Expr) -> bool {
     match e.right {
-        None => e.literal >= 0,
+        None => e.op == Operator::Literal,
         Some(right) => e.op == Operator::Parens || ok_before_keyword(unsafe { &*right.as_ptr() }),
     }
 }
@@ -107,7 +123,7 @@ pub fn ok_before_keyword(e: &Expr) -> bool {
 // "or3", "orn" are invalid. Need a unary op or parens.
 pub fn ok_after_keyword(e: &Expr) -> bool {
     match e.left {
-        None => e.op != Operator::Literal,
+        None => e.op != Operator::Literal && e.op != Operator::Variable,
         Some(left) => ok_after_keyword(unsafe { &*left.as_ptr() }),
     }
 }

--- a/src/operator.rs
+++ b/src/operator.rs
@@ -30,7 +30,7 @@ pub enum Operator {
     Exp = 0xD0,
     Parens = 0xE0,
     Literal = 0xF0,
-    Variable = 0xF1
+    Variable = 0xF1,
 }
 
 impl Display for Operator {
@@ -62,8 +62,7 @@ impl Display for Operator {
             Operator::BitNeg => write!(f, "~"),
             Operator::Exp => write!(f, "**"),
             Operator::Parens => write!(f, "("),
-            Operator::Literal |
-            Operator::Variable => write!(f, ""),
+            Operator::Literal | Operator::Variable => write!(f, ""),
         }
     }
 }

--- a/src/operator.rs
+++ b/src/operator.rs
@@ -30,6 +30,7 @@ pub enum Operator {
     Exp = 0xD0,
     Parens = 0xE0,
     Literal = 0xF0,
+    Variable = 0xF1
 }
 
 impl Display for Operator {
@@ -61,7 +62,8 @@ impl Display for Operator {
             Operator::BitNeg => write!(f, "~"),
             Operator::Exp => write!(f, "**"),
             Operator::Parens => write!(f, "("),
-            Operator::Literal => write!(f, ""),
+            Operator::Literal |
+            Operator::Variable => write!(f, ""),
         }
     }
 }

--- a/src/params.rs
+++ b/src/params.rs
@@ -23,8 +23,8 @@ pub fn mapping(n: Num) -> Num {
     n
 }
 
-pub fn match_goal(output: &Vector, _expr: &Expr) -> bool {
-    output.clone().map(mapping) == Vector::from_slice(GOAL)
+pub fn match_goal(expr: &Expr) -> bool {
+    expr.output.clone().map(mapping) == Vector::from_slice(GOAL)
 }
 
 pub const GOAL: &[Num] = &[1, -1, 0, 0];

--- a/src/vec.rs
+++ b/src/vec.rs
@@ -5,7 +5,7 @@ use crate::{
     params::{Num, C_STYLE_MOD, GOAL},
 };
 
-#[derive(Clone, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
 pub struct Vector([Num; GOAL.len()]);
 
 impl Vector {

--- a/src/vec.rs
+++ b/src/vec.rs
@@ -5,7 +5,7 @@ use crate::{
     params::{Num, C_STYLE_MOD, GOAL},
 };
 
-#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
 pub struct Vector([Num; GOAL.len()]);
 
 impl Vector {
@@ -80,7 +80,7 @@ impl_op!(BitXor, bitxor, ^=);
 impl_op!(Shl, shl, <<=);
 impl_op!(Shr, shr, >>=);
 impl_unary!(Not, not, !);
-impl_unary!(Neg, neg, (|x|0-x));
+impl_unary!(Neg, neg, (|x| 0 - x));
 
 pub fn divmod(left: &Vector, right: &Vector) -> Option<(Vector, Vector)> {
     if left


### PR DESCRIPTION
Placed the output in `Expr` & removed the `literal` field & used a `HashSet` instead of a `HashMap`.

#### Benefits:
- +5-10% performance boost
- Uses less memory if `Num = i32` & `len() % 2 != 0` or if  `Num = i16` & `len() % 4 != 0`  (in 64 bit environments)
- Enables future implementation of chained operators