### PR TITLE
Choose multithread based on level

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,11 +10,10 @@ overflow-checks = false
 
 [features]
 simd = []
-rayon = ["dep:rayon", "hashbrown/rayon"]
 
 [dependencies]
-rayon = { version = "1.7.0", optional = true }
-hashbrown = "0.14.0"
+rayon = "1.7.0"
+hashbrown = { version = "0.14.0", features = ["rayon"]}
 num-integer = "0.1.45"
 
 # Doesn't seem to help much:

--- a/README.md
+++ b/README.md
@@ -8,8 +8,6 @@ Edit the search parameters at the top of `src/params.rs`, then run `cargo run --
 
 If your input/goal vectors have length ≤8, you can try `cargo +nightly run --release --features simd`.
 
-You can also pass `--features rayon` to enable multithreading, it should be faster but will use more memory.
-
 In `main.rs` you can edit the file used as the params module (default `#[path = "params.rs"]`). This way you can manage multiple configurations (e.g. make a `params-fizzbuzz.rs`).
 
 ## Example

--- a/src/main.rs
+++ b/src/main.rs
@@ -37,7 +37,6 @@ fn can_use_required_vars(mask: u8, length: usize) -> bool {
     !USE_ALL_VARS || length + (INPUTS.len() - (mask.count_ones() as usize)) * 2 <= MAX_LENGTH
 }
 
-#[cfg(feature = "rayon")]
 fn unit_if(b: bool) -> Option<()> {
     if b {
         Some(())
@@ -416,8 +415,7 @@ fn find_variables_and_literals(cn: &mut CacheLevel, n: usize) {
     }
 }
 
-#[cfg(feature = "rayon")]
-fn find_expressions(mut_cache: &mut Cache, n: usize) {
+fn find_expressions_multithread(mut_cache: &mut Cache, n: usize) {
     use rayon::{iter::Either, prelude::*};
 
     let cache = &mut_cache;
@@ -467,7 +465,6 @@ fn find_expressions(mut_cache: &mut Cache, n: usize) {
     mut_cache.push(cn);
 }
 
-#[cfg(not(feature = "rayon"))]
 fn find_expressions(cache: &mut Cache, n: usize) {
     let mut cn = CacheLevel::new();
     find_variables_and_literals(&mut cn, n);
@@ -505,7 +502,11 @@ fn main() {
             _ => println!("Finding length {n}-{MAX_LENGTH}..."),
         }
         let layer_start = Instant::now();
-        find_expressions(&mut cache, n);
+        if n >= MIN_MULTITHREAD_LENGTH {
+            find_expressions_multithread(&mut cache, n);
+        } else {
+            find_expressions(&mut cache, n);
+        }
         let count = cache[n].len();
         total_count += count;
         let time = layer_start.elapsed();

--- a/src/params.rs
+++ b/src/params.rs
@@ -31,6 +31,7 @@ pub const GOAL: &[Num] = &[1, -1, 0, 0];
 
 pub const MAX_LENGTH: usize = 14;
 pub const MAX_CACHE_LENGTH: usize = 10;
+pub const MIN_MULTITHREAD_LENGTH: usize = MAX_CACHE_LENGTH + 1;
 pub const LITERALS: &[Num] = &[
     1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26,
     27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40,


### PR DESCRIPTION
Multithreading is faster but uses more memory when building cache, so the ideal trade off is to use a single thread up to MAX_CACHE_LENGTH to save memory and then DFS using multithread.