### PR TITLE
Inline map function from Vector

### DIFF
--- a/src/vec.rs
+++ b/src/vec.rs
@@ -14,6 +14,7 @@ impl Vector {
         Vector(ns.try_into().expect("slice have same length"))
     }
 
+    #[inline]
     pub fn map(mut self, function: fn(Num) -> Num) -> Vector {
         for x in &mut self.0.iter_mut() {
             *x = function(*x)


### PR DESCRIPTION
For some reason, Rust fails to auto-inline the `map` function in `Vector`, which makes the code run disturbingly slow for certain input lengths.

To demonstrate this, I plotted below the individual execution times (y-axis) for different input/goal lengths from 8 to 64. The red is without `#[inline]`, the green is with `#[inline]`, and the blue replaces the logic in `match_goal()` from `expr.output.clone().map(mapping)` to `expr.output`:

<img width="543" alt="image" src="https://github.com/lynn/pysearch/assets/44751422/f501e9dd-51ab-4065-b5db-13ba27abbbfa">

For whatever reason, the blue (removing the `map` entirely) seems to run slightly faster and more consistently than the green (inlined `map`) at least on my machine. Perhaps that is a discussion for another time.

P.S. I also confirmed this with @4atj, who was able to reproduce the same behavior.