### PR TITLE
Operator refactor

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,9 @@ edition = "2021"
 [profile.dev]
 overflow-checks = false
 
+[profile.release]
+opt-level = 3
+
 [features]
 simd = []
 
@@ -15,6 +18,7 @@ simd = []
 rayon = "1.7.0"
 hashbrown = { version = "0.14.0" }
 num-integer = "0.1.45"
+seq-macro = "0.3"
 
 # Doesn't seem to help much:
 # [profile.release]

--- a/src/main.rs
+++ b/src/main.rs
@@ -10,14 +10,13 @@ pub mod params;
 #[cfg_attr(not(feature = "simd"), path = "vec.rs")]
 pub mod vec;
 
-use expr::{ok_after_keyword, ok_before_keyword, Expr, Mask, NonNullExpr};
-use operator::Operator;
+use expr::{Expr, Mask, NonNullExpr};
+use operator::{BinaryOperator, Operator};
 use params::*;
 
-use vec::{divmod, vec_bit_shl, vec_bit_shr, vec_gcd, vec_le, vec_lt, vec_or, vec_pow, Vector};
+use vec::Vector;
 
 use hashbrown::{hash_set::Entry, HashMap, HashSet};
-use std::ptr::NonNull;
 use std::time::Instant;
 
 // cache[length][output] = highest-prec expression of that length yielding that output
@@ -102,19 +101,18 @@ fn save(level: &mut CacheLevel, expr: Expr, n: usize, cache: &Cache, hashset_cac
     level.push(expr);
 }
 
-fn find_1_byte_operators(
+fn apply_binary_operator(
     cn: &mut CacheLevel,
     cache: &Cache,
     hashset_cache: &HashSetCache,
     n: usize,
     el: &Expr,
     er: &Expr,
+    op: BinaryOperator,
 ) {
     if er.is_literal() && el.is_literal() {
         return;
     }
-    let elp: NonNull<Expr> = el.into();
-    let erp: NonNull<Expr> = er.into();
     if !REUSE_VARS && (el.var_mask & er.var_mask != 0) {
         return;
     }
@@ -122,237 +120,15 @@ fn find_1_byte_operators(
     if !can_use_required_vars(mask, n) {
         return;
     }
-    let ol = &el.output;
-    let or = &er.output;
-    // For commutative operators, choose an arbitrary order for the two operands based on memory
-    // address.
-    let use_commutative_op = |prec| el.prec() >= prec && er.prec() >= prec && elp <= erp;
-    if USE_LT && el.prec() >= 5 && er.prec() > 5 {
-        save(
-            cn,
-            Expr::bin(elp, erp, Operator::Lt, mask, vec_lt(ol, or)),
-            n,
-            cache,
-            hashset_cache,
-        );
-    }
-    if USE_BIT_OR && use_commutative_op(6) {
-        save(
-            cn,
-            Expr::bin(elp, erp, Operator::BitOr, mask, ol.clone() | or),
-            n,
-            cache,
-            hashset_cache,
-        );
-    }
-    if USE_BIT_XOR && use_commutative_op(7) {
-        save(
-            cn,
-            Expr::bin(elp, erp, Operator::BitXor, mask, ol.clone() ^ or),
-            n,
-            cache,
-            hashset_cache,
-        );
-    }
-    if USE_BIT_AND && use_commutative_op(8) {
-        save(
-            cn,
-            Expr::bin(elp, erp, Operator::BitAnd, mask, ol.clone() & or),
-            n,
-            cache,
-            hashset_cache,
-        );
-    }
-    if USE_ADD && use_commutative_op(10) {
-        save(
-            cn,
-            Expr::bin(elp, erp, Operator::Add, mask, ol.clone() + or),
-            n,
-            cache,
-            hashset_cache,
-        );
-    }
-    if USE_SUB && el.prec() >= 10 && er.prec() > 10 {
-        save(
-            cn,
-            Expr::bin(elp, erp, Operator::Sub, mask, ol.clone() - or),
-            n,
-            cache,
-            hashset_cache,
-        );
-    }
-    // No `use_commutative_op` here because there are other operators with precedence 11 that could
-    // break commutativity.
-    if USE_MUL && er.prec() > 11 && (el.prec() > 11 && elp <= erp || el.prec() == 11) {
-        save(
-            cn,
-            Expr::bin(elp, erp, Operator::Mul, mask, ol.clone() * or),
-            n,
-            cache,
-            hashset_cache,
-        );
-    }
-    if el.prec() >= 11 && er.prec() > 11 {
-        if let Some((div, modulo)) = divmod(ol, or) {
-            if USE_MOD {
-                save(
-                    cn,
-                    Expr::bin(elp, erp, Operator::Mod, mask, modulo),
-                    n,
-                    cache,
-                    hashset_cache,
-                );
-            }
-            if USE_DIV1 {
-                save(
-                    cn,
-                    Expr::bin(elp, erp, Operator::Div1, mask, div),
-                    n,
-                    cache,
-                    hashset_cache,
-                );
-            }
-        }
-        if USE_GCD {
+    if op.can_apply(el, er) {
+        if let Some(output) = op.vec_apply(el.output.clone(), &er.output) {
             save(
                 cn,
-                Expr::bin(elp, erp, Operator::Gcd, mask, vec_gcd(ol, or)),
+                Expr::bin(el.into(), er.into(), op.into(), mask, output),
                 n,
                 cache,
                 hashset_cache,
             );
-        }
-    }
-}
-
-fn find_2_byte_operators(
-    cn: &mut CacheLevel,
-    cache: &Cache,
-    hashset_cache: &HashSetCache,
-    n: usize,
-    el: &Expr,
-    er: &Expr,
-) {
-    if er.is_literal() && el.is_literal() {
-        return;
-    }
-    let elp: NonNull<Expr> = el.into();
-    let erp: NonNull<Expr> = er.into();
-    if !REUSE_VARS && (el.var_mask & er.var_mask != 0) {
-        return;
-    }
-    let mask = el.var_mask | er.var_mask;
-    if !can_use_required_vars(mask, n) {
-        return;
-    }
-    let ol = &el.output;
-    let or = &er.output;
-    if USE_OR && el.prec() >= 3 && er.prec() > 3 && ok_before_keyword(el) && ok_after_keyword(er) {
-        save(
-            cn,
-            Expr::bin(elp, erp, Operator::Or, mask, vec_or(ol, or)),
-            n,
-            cache,
-            hashset_cache,
-        );
-    }
-    if USE_LE && el.prec() >= 5 && er.prec() > 5 {
-        save(
-            cn,
-            Expr::bin(elp, erp, Operator::Le, mask, vec_le(ol, or)),
-            n,
-            cache,
-            hashset_cache,
-        );
-    }
-    if el.prec() >= 9 && er.prec() > 9 {
-        if USE_BIT_SHL {
-            if let Some(output) = vec_bit_shl(ol, or) {
-                save(
-                    cn,
-                    Expr::bin(elp, erp, Operator::BitShl, mask, output),
-                    n,
-                    cache,
-                    hashset_cache,
-                );
-            }
-        }
-        if USE_BIT_SHR {
-            if let Some(output) = vec_bit_shr(ol, or) {
-                save(
-                    cn,
-                    Expr::bin(elp, erp, Operator::BitShr, mask, output),
-                    n,
-                    cache,
-                    hashset_cache,
-                );
-            }
-        }
-    }
-    if USE_DIV2 && el.prec() >= 11 && er.prec() > 11 {
-        if let Some((div, _)) = divmod(ol, or) {
-            save(
-                cn,
-                Expr::bin(elp, erp, Operator::Div2, mask, div),
-                n,
-                cache,
-                hashset_cache,
-            );
-        }
-    }
-    if USE_EXP && el.prec() > 13 && er.prec() >= 13 {
-        if let Some(output) = vec_pow(ol, or) {
-            save(
-                cn,
-                Expr::bin(elp, erp, Operator::Exp, mask, output),
-                n,
-                cache,
-                hashset_cache,
-            );
-        }
-    }
-}
-
-fn find_3_byte_operators(
-    cn: &mut CacheLevel,
-    cache: &Cache,
-    hashset_cache: &HashSetCache,
-    n: usize,
-    el: &Expr,
-    er: &Expr,
-) {
-    if er.is_literal() && el.is_literal() {
-        return;
-    }
-    let elp: NonNull<Expr> = el.into();
-    let erp: NonNull<Expr> = er.into();
-    if !REUSE_VARS && (el.var_mask & er.var_mask != 0) {
-        return;
-    }
-    let mask = el.var_mask | er.var_mask;
-    if !can_use_required_vars(mask, n) {
-        return;
-    }
-    let ol = &el.output;
-    let or = &er.output;
-    if USE_OR && el.prec() >= 3 && er.prec() > 3 {
-        let z = vec_or(ol, or);
-        match (ok_before_keyword(el), ok_after_keyword(er)) {
-            (true, false) => save(
-                cn,
-                Expr::bin(elp, erp, Operator::OrSpace, mask, z),
-                n,
-                cache,
-                hashset_cache,
-            ),
-            (false, true) => save(
-                cn,
-                Expr::bin(elp, erp, Operator::SpaceOr, mask, z),
-                n,
-                cache,
-                hashset_cache,
-            ),
-            _ => {}
         }
     }
 }
@@ -363,22 +139,20 @@ fn find_binary_expressions_left(
     hashset_cache: &HashSetCache,
     n: usize,
     k: usize,
-    r: &Expr,
+    er: &Expr,
 ) {
-    for l in &cache[n - k - 1] {
-        find_1_byte_operators(cn, cache, hashset_cache, n, l, r);
-    }
-    if n < k + 3 {
-        return;
-    }
-    for l in &cache[n - k - 2] {
-        find_2_byte_operators(cn, cache, hashset_cache, n, l, r);
-    }
-    if n < k + 4 {
-        return;
-    }
-    for l in &cache[n - k - 3] {
-        find_3_byte_operators(cn, cache, hashset_cache, n, l, r);
+    for &op in BINARY_OPERATORS {
+        if k + op.length() >= n {
+            continue;
+        }
+        if !op.can_apply_right(er) {
+            continue;
+        }
+        for el in &cache[n - k - op.length()] {
+            if op.can_apply_left(el) {
+                apply_binary_operator(cn, cache, hashset_cache, n, el, er, op)
+            }
+        }
     }
 }
 
@@ -388,22 +162,20 @@ fn find_binary_expressions_right(
     hashset_cache: &HashSetCache,
     n: usize,
     k: usize,
-    l: &Expr,
+    el: &Expr,
 ) {
-    for r in &cache[n - k - 1] {
-        find_1_byte_operators(cn, cache, hashset_cache, n, l, r);
-    }
-    if n < k + 3 {
-        return;
-    }
-    for r in &cache[n - k - 2] {
-        find_2_byte_operators(cn, cache, hashset_cache, n, l, r);
-    }
-    if n < k + 4 {
-        return;
-    }
-    for r in &cache[n - k - 3] {
-        find_3_byte_operators(cn, cache, hashset_cache, n, l, r);
+    for &op in BINARY_OPERATORS {
+        if k + op.length() >= n {
+            continue;
+        }
+        if !op.can_apply_left(el) {
+            continue;
+        }
+        for er in &cache[n - k - op.length()] {
+            if op.can_apply_right(er) {
+                apply_binary_operator(cn, cache, hashset_cache, n, el, er, op)
+            }
+        }
     }
 }
 
@@ -417,27 +189,16 @@ fn find_unary_expression(
     if !can_use_required_vars(er.var_mask, n) {
         return;
     }
-    if er.prec() < 12 {
-        return;
-    }
-    let or = &er.output;
-    if USE_BIT_NEG {
-        save(
-            cn,
-            Expr::unary(er, Operator::BitNeg, !or.clone()),
-            n,
-            cache,
-            hashset_cache,
-        );
-    }
-    if USE_NEG {
-        save(
-            cn,
-            Expr::unary(er, Operator::Neg, -or.clone()),
-            n,
-            cache,
-            hashset_cache,
-        );
+    for &op in UNARY_OPERATORS {
+        if op.can_apply(er) {
+            save(
+                cn,
+                Expr::unary(er, op.into(), op.vec_apply(er.output.clone())),
+                n,
+                cache,
+                hashset_cache,
+            );
+        }
     }
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -11,12 +11,13 @@ pub mod params;
 pub mod vec;
 
 use expr::{Expr, Mask, NonNullExpr};
-use operator::{BinaryOperator, Operator};
+use operator::Operator;
 use params::*;
 
 use vec::Vector;
 
 use hashbrown::{hash_set::Entry, HashMap, HashSet};
+use seq_macro::seq;
 use std::time::Instant;
 
 // cache[length][output] = highest-prec expression of that length yielding that output
@@ -84,7 +85,7 @@ fn save(level: &mut CacheLevel, expr: Expr, n: usize, cache: &Cache, hashset_cac
             find_binary_expressions_right(level, cache, hashset_cache, dfs_len, n, &expr);
         }
         if n + 1 <= MAX_LENGTH {
-            find_unary_expression(level, cache, hashset_cache, n + 1, &expr);
+            find_unary_operators(level, cache, hashset_cache, n + 1, &expr);
         }
         if n + 2 < MAX_LENGTH && expr.op < Operator::Parens {
             save(
@@ -101,14 +102,15 @@ fn save(level: &mut CacheLevel, expr: Expr, n: usize, cache: &Cache, hashset_cac
     level.push(expr);
 }
 
-fn apply_binary_operator(
+#[inline(always)]
+fn find_binary_operators(
     cn: &mut CacheLevel,
     cache: &Cache,
     hashset_cache: &HashSetCache,
     n: usize,
     el: &Expr,
     er: &Expr,
-    op: BinaryOperator,
+    op_len: usize,
 ) {
     if er.is_literal() && el.is_literal() {
         return;
@@ -120,17 +122,21 @@ fn apply_binary_operator(
     if !can_use_required_vars(mask, n) {
         return;
     }
-    if op.can_apply(el, er) {
-        if let Some(output) = op.vec_apply(el.output.clone(), &er.output) {
-            save(
-                cn,
-                Expr::bin(el.into(), er.into(), op.into(), mask, output),
-                n,
-                cache,
-                hashset_cache,
-            );
+    seq!(op_idx in 0..100 {
+        if let Some(&op) = BINARY_OPERATORS.get(op_idx) {
+            if op.length() == op_len && op.can_apply(el, er) {
+                if let Some(output) = op.vec_apply(el.output.clone(), &er.output) {
+                    save(
+                        cn,
+                        Expr::bin(el.into(), er.into(), op.into(), mask, output),
+                        n,
+                        cache,
+                        hashset_cache,
+                    );
+                }
+            }
         }
-    }
+    });
 }
 
 fn find_binary_expressions_left(
@@ -141,19 +147,14 @@ fn find_binary_expressions_left(
     k: usize,
     er: &Expr,
 ) {
-    for &op in BINARY_OPERATORS {
-        if k + op.length() >= n {
-            continue;
+    seq!(op_len in 1..=3 {
+        if n <= k + op_len {
+            return;
+        };
+        for el in &cache[n - k - op_len] {
+            find_binary_operators(cn, cache, hashset_cache, n, el, er, op_len);
         }
-        if !op.can_apply_right(er) {
-            continue;
-        }
-        for el in &cache[n - k - op.length()] {
-            if op.can_apply_left(el) {
-                apply_binary_operator(cn, cache, hashset_cache, n, el, er, op)
-            }
-        }
-    }
+    });
 }
 
 fn find_binary_expressions_right(
@@ -164,22 +165,17 @@ fn find_binary_expressions_right(
     k: usize,
     el: &Expr,
 ) {
-    for &op in BINARY_OPERATORS {
-        if k + op.length() >= n {
-            continue;
+    seq!(op_len in 1..=3 {
+        if n <= k + op_len {
+            return;
+        };
+        for er in &cache[n - k - op_len] {
+            find_binary_operators(cn, cache, hashset_cache, n, el, er, op_len);
         }
-        if !op.can_apply_left(el) {
-            continue;
-        }
-        for er in &cache[n - k - op.length()] {
-            if op.can_apply_right(er) {
-                apply_binary_operator(cn, cache, hashset_cache, n, el, er, op)
-            }
-        }
-    }
+    });
 }
 
-fn find_unary_expression(
+fn find_unary_operators(
     cn: &mut CacheLevel,
     cache: &Cache,
     hashset_cache: &HashSetCache,
@@ -209,7 +205,7 @@ fn find_unary_expressions(
     n: usize,
 ) {
     for r in &cache[n - 1] {
-        find_unary_expression(cn, cache, hashset_cache, n, r);
+        find_unary_operators(cn, cache, hashset_cache, n, r);
     }
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -185,17 +185,19 @@ fn find_unary_operators(
     if !can_use_required_vars(er.var_mask, n) {
         return;
     }
-    for &op in UNARY_OPERATORS {
-        if op.can_apply(er) {
-            save(
-                cn,
-                Expr::unary(er, op.into(), op.vec_apply(er.output.clone())),
-                n,
-                cache,
-                hashset_cache,
-            );
+    seq!(op_idx in 0..10 {
+        if let Some(&op) = UNARY_OPERATORS.get(op_idx) {
+            if op.can_apply(er) {
+                save(
+                    cn,
+                    Expr::unary(er, op.into(), op.vec_apply(er.output.clone())),
+                    n,
+                    cache,
+                    hashset_cache,
+                );
+            }
         }
-    }
+    });
 }
 
 fn find_unary_expressions(

--- a/src/operator.rs
+++ b/src/operator.rs
@@ -1,18 +1,24 @@
 use std::fmt::Display;
 
+use crate::{
+    expr::{ok_after_keyword, ok_before_keyword, Expr},
+    params::{Num, C_STYLE_BIT_SHIFT, C_STYLE_MOD},
+    vec::Vector,
+};
+
 #[repr(u8)]
 #[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord)]
 pub enum Operator {
     Or = 0x30,
     SpaceOr = 0x31,
     OrSpace = 0x32,
-    // SpaceOrSpace = 0x303,
+    SpaceOrSpace = 0x33,
     Lt = 0x50,
     Le = 0x51,
-    // Gt = 0x502,
-    // Ge = 0x503,
-    // Eq = 0x504,
-    // Ne = 0x505,
+    Gt = 0x52,
+    Ge = 0x53,
+    Eq = 0x54,
+    Ne = 0x55,
     BitOr = 0x60,
     BitXor = 0x70,
     BitAnd = 0x80,
@@ -39,13 +45,13 @@ impl Display for Operator {
             Operator::Or => write!(f, "or"),
             Operator::SpaceOr => write!(f, " or"),
             Operator::OrSpace => write!(f, "or "),
-            // Operator::SpaceOrSpace => write!(f, " or "),
+            Operator::SpaceOrSpace => write!(f, " or "),
             Operator::Lt => write!(f, "<"),
             Operator::Le => write!(f, "<="),
-            // Operator::Gt => write!(f, ">"),
-            // Operator::Ge => write!(f, ">="),
-            // Operator::Eq => write!(f, "=="),
-            // Operator::Ne => write!(f, "!="),
+            Operator::Gt => write!(f, ">"),
+            Operator::Ge => write!(f, ">="),
+            Operator::Eq => write!(f, "=="),
+            Operator::Ne => write!(f, "!="),
             Operator::BitOr => write!(f, "|"),
             Operator::BitXor => write!(f, "^"),
             Operator::BitAnd => write!(f, "&"),
@@ -64,5 +70,221 @@ impl Display for Operator {
             Operator::Parens => write!(f, "("),
             Operator::Literal | Operator::Variable => write!(f, ""),
         }
+    }
+}
+
+impl From<UnaryOperator> for Operator {
+    fn from(op: UnaryOperator) -> Self {
+        match op {
+            UnaryOperator::Neg => Operator::Neg,
+            UnaryOperator::BitNeg => Operator::BitNeg,
+        }
+    }
+}
+
+impl From<BinaryOperator> for Operator {
+    fn from(op: BinaryOperator) -> Self {
+        use BinaryOperator::*;
+        match op {
+            Or => Operator::Or,
+            SpaceOr => Operator::SpaceOr,
+            OrSpace => Operator::OrSpace,
+            SpaceOrSpace => Operator::SpaceOrSpace,
+            Lt => Operator::Lt,
+            Le => Operator::Le,
+            Gt => Operator::Gt,
+            Ge => Operator::Ge,
+            Eq => Operator::Eq,
+            Ne => Operator::Ne,
+            BitOr => Operator::BitOr,
+            BitXor => Operator::BitXor,
+            BitAnd => Operator::BitAnd,
+            BitShl => Operator::BitShl,
+            BitShr => Operator::BitShr,
+            Add => Operator::Add,
+            Sub => Operator::Sub,
+            Mul => Operator::Mul,
+            Mod => Operator::Mod,
+            Div1 => Operator::Div1,
+            Div2 => Operator::Div2,
+            Gcd => Operator::Gcd,
+            Exp => Operator::Exp,
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord)]
+pub enum UnaryOperator {
+    Neg,
+    BitNeg,
+}
+
+impl UnaryOperator {
+    #[inline]
+    pub fn can_apply(&self, er: &Expr) -> bool {
+        er.prec() >= 12
+    }
+
+    pub fn apply(&self, x: Num) -> Num {
+        match self {
+            UnaryOperator::Neg => 0 - x,
+            UnaryOperator::BitNeg => !x,
+        }
+    }
+
+    pub fn vec_apply(&self, v: Vector) -> Vector {
+        v.map(|x| self.apply(x))
+    }
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord)]
+pub enum BinaryOperator {
+    Or,
+    SpaceOr,
+    OrSpace,
+    SpaceOrSpace,
+    Lt,
+    Le,
+    Gt,
+    Ge,
+    Eq,
+    Ne,
+    BitOr,
+    BitXor,
+    BitAnd,
+    BitShl,
+    BitShr,
+    Add,
+    Sub,
+    Mul,
+    Mod,
+    Div1,
+    Div2,
+    Gcd,
+    Exp,
+}
+
+impl BinaryOperator {
+    pub fn length(&self) -> usize {
+        use BinaryOperator::*;
+        match self {
+            Lt | Gt | BitOr | BitXor | BitAnd | Add | Sub | Mul | Mod | Div1 | Gcd => 1,
+            Or | Le | Ge | Eq | Ne | BitShl | BitShr | Div2 | Exp => 2,
+            SpaceOr | OrSpace => 3,
+            SpaceOrSpace => 4,
+        }
+    }
+
+    #[inline]
+    pub fn can_apply_left(&self, el: &Expr) -> bool {
+        use BinaryOperator::*;
+
+        match self {
+            Or | SpaceOr => el.prec() >= 3 && ok_before_keyword(el),
+            OrSpace | SpaceOrSpace => el.prec() >= 3 && ok_before_keyword(el),
+            Lt | Le | Gt | Ge | Eq | Ne => el.prec() >= 5,
+            BitOr => el.prec() >= 6,
+            BitXor => el.prec() >= 7,
+            BitAnd => el.prec() >= 8,
+            BitShl | BitShr => el.prec() >= 9,
+            Add | Sub => el.prec() >= 10,
+            Mul | Mod | Div1 | Div2 | Gcd => el.prec() >= 11,
+            Exp => el.prec() > 13,
+        }
+    }
+
+    #[inline]
+    pub fn can_apply_right(&self, er: &Expr) -> bool {
+        use BinaryOperator::*;
+
+        match self {
+            Or | SpaceOr => er.prec() > 3 && ok_after_keyword(er),
+            OrSpace | SpaceOrSpace => er.prec() > 3 && !ok_after_keyword(er),
+            Lt | Le | Gt | Ge | Eq | Ne => er.prec() > 5,
+            BitOr => er.prec() >= 6,
+            BitXor => er.prec() >= 7,
+            BitAnd => er.prec() >= 8,
+            BitShl | BitShr => er.prec() > 9,
+            Add => er.prec() >= 10,
+            Sub => er.prec() > 10,
+            Mul | Mod | Div1 | Div2 | Gcd => er.prec() > 11,
+            Exp => er.prec() >= 13,
+        }
+    }
+
+    #[inline]
+    pub fn can_apply(&self, el: &Expr, er: &Expr) -> bool {
+        use BinaryOperator::*;
+
+        match self {
+            Or | SpaceOr | OrSpace | SpaceOrSpace | Lt | Le | Gt | Ge | Eq | Ne | BitShl
+            | BitShr | Sub | Mod | Div1 | Div2 | Gcd | Exp => true,
+            BitOr | BitXor | BitAnd | Add => el as *const Expr <= er as *const Expr,
+            Mul => el.prec() == 11 || el as *const Expr <= er as *const Expr,
+        }
+    }
+
+    pub fn apply(&self, x: Num, y: Num) -> Option<Num> {
+        use BinaryOperator::*;
+        match self {
+            Or | SpaceOr | OrSpace | SpaceOrSpace => Some(if x != 0 { x } else { y }),
+            Lt => Some((x < y) as Num),
+            Le => Some((x <= y) as Num),
+            Gt => Some((x > y) as Num),
+            Ge => Some((x >= y) as Num),
+            Eq => Some((x == y) as Num),
+            Ne => Some((x != y) as Num),
+            BitOr => Some(x | y),
+            BitXor => Some(x ^ y),
+            BitAnd => Some(x & y),
+            BitShl => {
+                if C_STYLE_BIT_SHIFT || y >= 0 && y < Num::BITS as Num {
+                    Some(x << y)
+                } else {
+                    None
+                }
+            }
+            BitShr => {
+                if C_STYLE_BIT_SHIFT {
+                    Some(x << y)
+                } else if y >= 0 {
+                    Some(x >> y.min(Num::BITS as Num - 1))
+                } else {
+                    None
+                }
+            }
+            Add => Some(x + y),
+            Sub => Some(x - y),
+            Mul => Some(x * y),
+            Mod => {
+                if C_STYLE_MOD {
+                    x.checked_rem(y)
+                } else {
+                    if y == 0 || (Num::MIN < 0 && x == Num::MIN && y == !0) {
+                        return None;
+                    }
+                    Some(num_integer::mod_floor(x, y))
+                }
+            }
+            Div1 | Div2 => {
+                if C_STYLE_MOD {
+                    x.checked_div(y)
+                } else {
+                    if y == 0 || (Num::MIN < 0 && x == Num::MIN && y == !0) {
+                        return None;
+                    }
+                    Some(num_integer::div_floor(x, y))
+                }
+            }
+            Gcd => Some(num_integer::gcd(x, y)),
+            Exp => x.checked_pow(y.try_into().ok()?),
+        }
+    }
+
+    pub fn vec_apply(&self, mut left: Vector, right: &Vector) -> Option<Vector> {
+        for (x, y) in left.iter_mut().zip(right.iter()) {
+            *x = self.apply(*x, *y)?;
+        }
+        Some(left)
     }
 }

--- a/src/params.rs
+++ b/src/params.rs
@@ -1,4 +1,8 @@
-use crate::{expr::Expr, vec::Vector};
+use crate::{
+    expr::Expr,
+    operator::{BinaryOperator, BinaryOperator::*, UnaryOperator, UnaryOperator::*},
+    vec::Vector,
+};
 
 pub type Num = i32;
 
@@ -39,24 +43,38 @@ pub const LITERALS: &[Num] = &[
 /// If not 0, include all numbers in 1..=MAX_LITERAL in addition to LITERALS.
 pub const MAX_LITERAL: Num = 0;
 
-pub const USE_OR: bool = true;
-pub const USE_LT: bool = true;
-pub const USE_LE: bool = true;
-pub const USE_BIT_OR: bool = true;
-pub const USE_BIT_XOR: bool = true;
-pub const USE_BIT_AND: bool = true;
-pub const USE_BIT_SHL: bool = true;
-pub const USE_BIT_SHR: bool = true;
-pub const USE_BIT_NEG: bool = true;
-pub const USE_ADD: bool = true;
-pub const USE_SUB: bool = true;
-pub const USE_MUL: bool = true;
-pub const USE_MOD: bool = true;
-pub const USE_DIV1: bool = false; /* / */
-pub const USE_DIV2: bool = true; /* // */
-pub const USE_GCD: bool = false;
-pub const USE_NEG: bool = true;
-pub const USE_EXP: bool = true;
+#[rustfmt::skip]
+pub const BINARY_OPERATORS: &[BinaryOperator] = &[
+    Or,
+    SpaceOr,
+    OrSpace,
+    // SpaceOrSpace,
+    Lt,
+    Le,
+    // Gt,
+    // Ge,
+    // Eq,
+    // Ne,
+    BitOr,
+    BitXor,
+    BitAnd,
+    BitShl,
+    BitShr,
+    Add,
+    Sub,
+    Mul,
+    Mod,
+    // Div1,
+    Div2,
+    // Gcd,
+    Exp,
+];
+
+#[rustfmt::skip]
+pub const UNARY_OPERATORS: &[UnaryOperator] = &[
+    BitNeg,
+    Neg
+];
 
 /// Use C-style modulo and division (-2 % 10 == -2) rather than Python style (-2 % 10 == 8).
 pub const C_STYLE_MOD: bool = false;


### PR DESCRIPTION
Refactor the operators to define their own operations, instead of implementing them in vector, unblocks upcoming 1by1 feature.

Thanks to @4atj's optimization this refactor brings ~10% performance improvement too.