### PR TITLE
prec() optimization

### DIFF
--- a/src/expr.rs
+++ b/src/expr.rs
@@ -21,7 +21,7 @@ unsafe impl Send for Expr {}
 unsafe impl Sync for Expr {}
 
 impl Expr {
-    pub fn prec(&self) -> u8 {
+    pub fn prec(&self) -> Prec {
         self.op_idx.prec()
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -120,33 +120,29 @@ fn find_binary_operators(
         return;
     }
     seq!(idx in 0..100 {
-        if let Some(&op_idx) = OP_BINARY_INDEX_TABLE.get(idx) {
-            if let Some(op) = BINARY_OPERATORS.get(idx) {
-                if op.name.len() == op_len && op.can_apply(el, er) {
-                    if MATCH_1BY1 && is_leaf_expr(op_idx, n) {
-                        if el
-                            .output
-                            .iter()
-                            .zip(er.output.iter())
-                            .enumerate()
-                            .all(|(i, (&ol, &or))| match (op.apply)(ol, or) {
-                                Some(o) => match_one(i, o),
-                                None => false,
-                            })
-                        {
-                            println!("{}{}{}", el, op_idx, er);
-                        }
-                    } else {
-                        if let Some(output) = op.vec_apply(el.output.clone(), &er.output) {
-                            save(
-                                cn,
-                                Expr::bin(el.into(), er.into(), op_idx, mask, output),
-                                n,
-                                cache,
-                                hashset_cache,
-                            );
-                        }
+        if let (Some(&op_idx), Some(op)) = (OP_BINARY_INDEX_TABLE.get(idx), BINARY_OPERATORS.get(idx)) {
+            if op.name.len() == op_len && op.can_apply(el, er) {
+                if MATCH_1BY1 && is_leaf_expr(op_idx, n) {
+                    if el
+                        .output
+                        .iter()
+                        .zip(er.output.iter())
+                        .enumerate()
+                        .all(|(i, (&ol, &or))| match (op.apply)(ol, or) {
+                            Some(o) => match_one(i, o),
+                            None => false,
+                        })
+                    {
+                        println!("{}{}{}", el, op_idx, er);
                     }
+                } else if let Some(output) = op.vec_apply(el.output.clone(), &er.output) {
+                    save(
+                        cn,
+                        Expr::bin(el.into(), er.into(), op_idx, mask, output),
+                        n,
+                        cache,
+                        hashset_cache,
+                    );
                 }
             }
         }
@@ -200,27 +196,25 @@ fn find_unary_operators(
         return;
     }
     seq!(idx in 0..10 {
-        if let Some(&op_idx) = OP_UNARY_INDEX_TABLE.get(idx) {
-            if let Some(op) = UNARY_OPERATORS.get(idx) {
-                if op.can_apply(er) {
-                    if MATCH_1BY1 && is_leaf_expr(op_idx, n) {
-                        if er
-                            .output
-                            .iter()
-                            .enumerate()
-                            .all(|(i, &or)| match_one(i, (op.apply)(or)))
-                        {
-                            println!("{}{}", op_idx, er);
-                        }
-                    } else {
-                        save(
-                            cn,
-                            Expr::unary(er, op_idx, op.vec_apply(er.output.clone())),
-                            n,
-                            cache,
-                            hashset_cache,
-                        );
+        if let (Some(&op_idx), Some(op)) = (OP_UNARY_INDEX_TABLE.get(idx), UNARY_OPERATORS.get(idx)) {
+            if op.can_apply(er) {
+                if MATCH_1BY1 && is_leaf_expr(op_idx, n) {
+                    if er
+                        .output
+                        .iter()
+                        .enumerate()
+                        .all(|(i, &or)| match_one(i, (op.apply)(or)))
+                    {
+                        println!("{}{}", op_idx, er);
                     }
+                } else {
+                    save(
+                        cn,
+                        Expr::unary(er, op_idx, op.vec_apply(er.output.clone())),
+                        n,
+                        cache,
+                        hashset_cache,
+                    );
                 }
             }
         }

--- a/src/operator.rs
+++ b/src/operator.rs
@@ -6,6 +6,8 @@ use crate::{
     vec::Vector,
 };
 
+pub type Prec = u8;
+
 #[derive(Clone, Copy, Debug, Eq, PartialEq, PartialOrd)]
 pub struct OpIndex(u8);
 
@@ -21,7 +23,7 @@ impl OpIndex {
     }
 
     #[inline(always)]
-    pub const fn prec(&self) -> u8 {
+    pub const fn prec(&self) -> Prec {
         self.0 >> 4
     }
 
@@ -40,7 +42,7 @@ impl Display for OpIndex {
 #[derive(Clone, Copy)]
 pub struct UnaryOp {
     pub name: &'static str,
-    pub prec: u8,
+    pub prec: Prec,
     pub apply: fn(Num) -> Num,
     pub can_apply: fn(&Expr) -> bool,
 }
@@ -48,7 +50,7 @@ pub struct UnaryOp {
 #[derive(Clone, Copy)]
 pub struct BinaryOp {
     pub name: &'static str,
-    pub prec: u8,
+    pub prec: Prec,
     pub apply: fn(Num, Num) -> Option<Num>,
     pub can_apply: fn(&Expr, &Expr) -> bool,
     pub commutative: bool,
@@ -56,7 +58,7 @@ pub struct BinaryOp {
 }
 
 impl UnaryOp {
-    pub const PREC: u8 = 12;
+    pub const PREC: Prec = 12;
 
     #[inline(always)]
     pub fn vec_apply(&self, v: Vector) -> Vector {

--- a/src/operator.rs
+++ b/src/operator.rs
@@ -22,7 +22,7 @@ impl OpIndex {
 
     #[inline(always)]
     pub const fn prec(&self) -> u8 {
-        OP_PREC_TABLE[self.as_index()]
+        self.0 >> 4
     }
 
     #[inline(always)]
@@ -55,8 +55,6 @@ pub struct BinaryOp {
     pub right_assoc: bool,
 }
 
-pub const MAX_OP_PREC: u8 = 255;
-
 impl UnaryOp {
     pub const PREC: u8 = 12;
 
@@ -72,6 +70,15 @@ impl UnaryOp {
 }
 
 impl BinaryOp {
+    const OP_EMPTY: BinaryOp = BinaryOp {
+        name: "",
+        prec: 0,
+        apply: apply_add,
+        can_apply: can_apply_binary_always,
+        commutative: false,
+        right_assoc: false,
+    };
+
     #[inline(always)]
     pub fn vec_apply(&self, mut vl: Vector, vr: &Vector) -> Option<Vector> {
         for (x, y) in vl.iter_mut().zip(vr.iter()) {
@@ -228,208 +235,170 @@ pub const OP_OR: BinaryOp = BinaryOp {
     prec: 3,
     apply: apply_or,
     can_apply: can_apply_or,
-    commutative: false,
-    right_assoc: false,
+    ..BinaryOp::OP_EMPTY
 };
 pub const OP_SPACE_OR: BinaryOp = BinaryOp {
     name: " or",
     prec: 3,
     apply: apply_or,
     can_apply: can_apply_space_or,
-    commutative: false,
-    right_assoc: false,
+    ..BinaryOp::OP_EMPTY
 };
 pub const OP_OR_SPACE: BinaryOp = BinaryOp {
     name: "or ",
     prec: 3,
     apply: apply_or,
     can_apply: can_apply_or_space,
-    commutative: false,
-    right_assoc: false,
+    ..BinaryOp::OP_EMPTY
 };
 pub const OP_SPACE_OR_SPACE: BinaryOp = BinaryOp {
     name: " or ",
     prec: 3,
     apply: apply_or,
     can_apply: can_apply_space_or_space,
-    commutative: false,
-    right_assoc: false,
+    ..BinaryOp::OP_EMPTY
 };
 pub const OP_LT: BinaryOp = BinaryOp {
     name: "<",
     prec: 5,
     apply: apply_lt,
-    can_apply: can_apply_binary_always,
-    commutative: false,
-    right_assoc: false,
+    ..BinaryOp::OP_EMPTY
 };
 pub const OP_LE: BinaryOp = BinaryOp {
     name: "<=",
     prec: 5,
     apply: apply_le,
-    can_apply: can_apply_binary_always,
-    commutative: false,
-    right_assoc: false,
+    ..BinaryOp::OP_EMPTY
 };
 pub const OP_GT: BinaryOp = BinaryOp {
     name: ">",
     prec: 5,
     apply: apply_gt,
-    can_apply: can_apply_binary_always,
-    commutative: false,
-    right_assoc: false,
+    ..BinaryOp::OP_EMPTY
 };
 pub const OP_GE: BinaryOp = BinaryOp {
     name: ">=",
     prec: 5,
     apply: apply_ge,
-    can_apply: can_apply_binary_always,
-    commutative: false,
-    right_assoc: false,
+    ..BinaryOp::OP_EMPTY
 };
 pub const OP_EQ: BinaryOp = BinaryOp {
     name: "==",
     prec: 5,
     apply: apply_eq,
-    can_apply: can_apply_binary_always,
-    commutative: false,
-    right_assoc: false,
+    commutative: true,
+    ..BinaryOp::OP_EMPTY
 };
 pub const OP_NE: BinaryOp = BinaryOp {
     name: "!=",
     prec: 5,
     apply: apply_ne,
-    can_apply: can_apply_binary_always,
-    commutative: false,
-    right_assoc: false,
+    commutative: true,
+    ..BinaryOp::OP_EMPTY
 };
 pub const OP_BIT_OR: BinaryOp = BinaryOp {
     name: "|",
     prec: 6,
     apply: apply_bit_or,
-    can_apply: can_apply_binary_always,
     commutative: true,
-    right_assoc: false,
+    ..BinaryOp::OP_EMPTY
 };
 pub const OP_BIT_XOR: BinaryOp = BinaryOp {
     name: "^",
     prec: 7,
     apply: apply_bit_xor,
-    can_apply: can_apply_binary_always,
     commutative: true,
-    right_assoc: false,
+    ..BinaryOp::OP_EMPTY
 };
 pub const OP_BIT_AND: BinaryOp = BinaryOp {
     name: "&",
     prec: 8,
     apply: apply_bit_and,
-    can_apply: can_apply_binary_always,
     commutative: true,
-    right_assoc: false,
+    ..BinaryOp::OP_EMPTY
 };
 pub const OP_BIT_SHL: BinaryOp = BinaryOp {
     name: "<<",
     prec: 9,
     apply: apply_bit_shl,
-    can_apply: can_apply_binary_always,
     commutative: false,
-    right_assoc: false,
+    ..BinaryOp::OP_EMPTY
 };
 pub const OP_BIT_SHL_WRAP: BinaryOp = BinaryOp {
     name: "<<",
     prec: 9,
     apply: apply_bit_shl_wrap,
-    can_apply: can_apply_binary_always,
-    commutative: false,
-    right_assoc: false,
+    ..BinaryOp::OP_EMPTY
 };
 pub const OP_BIT_SHR: BinaryOp = BinaryOp {
     name: ">>",
     prec: 9,
     apply: apply_bit_shr,
-    can_apply: can_apply_binary_always,
-    commutative: false,
-    right_assoc: false,
+    ..BinaryOp::OP_EMPTY
 };
 pub const OP_BIT_SHR_WRAP: BinaryOp = BinaryOp {
     name: ">>",
     prec: 9,
     apply: apply_bit_shr_wrap,
-    can_apply: can_apply_binary_always,
-    commutative: false,
-    right_assoc: false,
+    ..BinaryOp::OP_EMPTY
 };
 pub const OP_ADD: BinaryOp = BinaryOp {
     name: "+",
     prec: 10,
     apply: apply_add,
-    can_apply: can_apply_binary_always,
     commutative: true,
-    right_assoc: false,
+    ..BinaryOp::OP_EMPTY
 };
 pub const OP_SUB: BinaryOp = BinaryOp {
     name: "-",
     prec: 10,
     apply: apply_sub,
-    can_apply: can_apply_binary_always,
-    commutative: false,
-    right_assoc: false,
+    ..BinaryOp::OP_EMPTY
 };
 pub const OP_MUL: BinaryOp = BinaryOp {
     name: "*",
     prec: 11,
     apply: apply_mul,
-    can_apply: can_apply_binary_always,
     commutative: true,
-    right_assoc: false,
+    ..BinaryOp::OP_EMPTY
 };
 pub const OP_MOD_FLOOR: BinaryOp = BinaryOp {
     name: "%",
     prec: 11,
     apply: apply_mod_floor,
-    can_apply: can_apply_binary_always,
-    commutative: false,
-    right_assoc: false,
+    ..BinaryOp::OP_EMPTY
 };
 pub const OP_MOD_TRUNC: BinaryOp = BinaryOp {
     name: "%",
     prec: 11,
     apply: apply_mod_trunc,
-    can_apply: can_apply_binary_always,
-    commutative: false,
-    right_assoc: false,
+    ..BinaryOp::OP_EMPTY
 };
 pub const OP_DIV_FLOOR: BinaryOp = BinaryOp {
     name: "//",
     prec: 11,
     apply: apply_div_floor,
-    can_apply: can_apply_binary_always,
-    commutative: false,
-    right_assoc: false,
+    ..BinaryOp::OP_EMPTY
 };
 pub const OP_DIV_TRUNC: BinaryOp = BinaryOp {
     name: "/",
     prec: 11,
     apply: apply_div_trunc,
-    can_apply: can_apply_binary_always,
-    commutative: false,
-    right_assoc: false,
+    ..BinaryOp::OP_EMPTY
 };
 pub const OP_GCD: BinaryOp = BinaryOp {
     name: "V",
     prec: 11,
     apply: apply_gcd,
-    can_apply: can_apply_binary_always,
     commutative: true,
-    right_assoc: false,
+    ..BinaryOp::OP_EMPTY
 };
 pub const OP_EXP: BinaryOp = BinaryOp {
     name: "**",
     prec: 13,
     apply: apply_exp,
-    can_apply: can_apply_binary_always,
-    commutative: false,
     right_assoc: true,
+    ..BinaryOp::OP_EMPTY
 };
 pub const OP_BIT_NEG: UnaryOp = UnaryOp {
     name: "~",
@@ -446,40 +415,52 @@ pub const OP_NEG: UnaryOp = UnaryOp {
 
 // All operators: [..Unary, ..Binary, Parens, Literal, Variable]
 pub const NUM_OPERATORS: usize = UNARY_OPERATORS.len() + BINARY_OPERATORS.len() + 3;
-pub const OP_INDEX_PARENS: OpIndex = OpIndex::new(NUM_OPERATORS - 3);
-pub const OP_INDEX_LITERAL: OpIndex = OpIndex::new(NUM_OPERATORS - 2);
-pub const OP_INDEX_VARIABLE: OpIndex = OpIndex::new(NUM_OPERATORS - 1);
+pub const OP_INDEX_PARENS: OpIndex = OpIndex::new(0xFD);
+pub const OP_INDEX_LITERAL: OpIndex = OpIndex::new(0xFE);
+pub const OP_INDEX_VARIABLE: OpIndex = OpIndex::new(0xFF);
 
-const fn gen_op_name_table() -> [&'static str; NUM_OPERATORS] {
-    let mut table = [""; NUM_OPERATORS];
-    let mut idx: usize = 0;
-    while idx < UNARY_OPERATORS.len() {
-        table[idx] = UNARY_OPERATORS[idx].name;
-        idx += 1;
+const fn gen_binary_index_table() -> [OpIndex; BINARY_OPERATORS.len()] {
+    let mut table = [OpIndex::new(0); BINARY_OPERATORS.len()];
+    let mut cnt = [0; 16];
+    let mut i: usize = 0;
+    while i < BINARY_OPERATORS.len() {
+        let prec = BINARY_OPERATORS[i].prec;
+        table[i] = OpIndex(prec << 4 | cnt[prec as usize]);
+        cnt[prec as usize] += 1;
+        i += 1;
     }
-    let mut idx: usize = 0;
-    while idx < BINARY_OPERATORS.len() {
-        table[idx + UNARY_OPERATORS.len()] = BINARY_OPERATORS[idx].name;
-        idx += 1;
+    table
+}
+
+const fn gen_unary_index_table() -> [OpIndex; UNARY_OPERATORS.len()] {
+    let mut table = [OpIndex::new(0); UNARY_OPERATORS.len()];
+    let mut cnt = [0; 16];
+    let mut i: usize = 0;
+    while i < UNARY_OPERATORS.len() {
+        let prec = UNARY_OPERATORS[i].prec;
+        table[i] = OpIndex(prec << 4 | cnt[prec as usize]);
+        cnt[prec as usize] += 1;
+        i += 1;
+    }
+    table
+}
+
+const fn gen_op_name_table() -> [&'static str; 256] {
+    let mut table = [""; 256];
+    let mut i: usize = 0;
+    while i < OP_BINARY_INDEX_TABLE.len() {
+        table[OP_BINARY_INDEX_TABLE[i].as_index()] = BINARY_OPERATORS[i].name;
+        i += 1;
+    }
+    let mut i: usize = 0;
+    while i < OP_UNARY_INDEX_TABLE.len() {
+        table[OP_UNARY_INDEX_TABLE[i].as_index()] = UNARY_OPERATORS[i].name;
+        i += 1;
     }
     table[OP_INDEX_PARENS.as_index()] = "(";
     table
 }
 
-const fn gen_op_prec_table() -> [u8; NUM_OPERATORS] {
-    let mut table = [MAX_OP_PREC; NUM_OPERATORS];
-    let mut idx: usize = 0;
-    while idx < UNARY_OPERATORS.len() {
-        table[idx] = UNARY_OPERATORS[idx].prec;
-        idx += 1;
-    }
-    let mut idx: usize = 0;
-    while idx < BINARY_OPERATORS.len() {
-        table[idx + UNARY_OPERATORS.len()] = BINARY_OPERATORS[idx].prec;
-        idx += 1;
-    }
-    table
-}
-
-pub const OP_NAME_TABLE: [&'static str; NUM_OPERATORS] = gen_op_name_table();
-pub const OP_PREC_TABLE: [u8; NUM_OPERATORS] = gen_op_prec_table();
+pub const OP_BINARY_INDEX_TABLE: [OpIndex; BINARY_OPERATORS.len()] = gen_binary_index_table();
+pub const OP_UNARY_INDEX_TABLE: [OpIndex; UNARY_OPERATORS.len()] = gen_unary_index_table();
+pub const OP_NAME_TABLE: [&'static str; 256] = gen_op_name_table();

--- a/src/operator.rs
+++ b/src/operator.rs
@@ -72,7 +72,7 @@ impl UnaryOp {
 }
 
 impl BinaryOp {
-    const OP_EMPTY: BinaryOp = BinaryOp {
+    const EMPTY: BinaryOp = BinaryOp {
         name: "",
         prec: 0,
         apply: apply_add,
@@ -237,170 +237,170 @@ pub const OP_OR: BinaryOp = BinaryOp {
     prec: 3,
     apply: apply_or,
     can_apply: can_apply_or,
-    ..BinaryOp::OP_EMPTY
+    ..BinaryOp::EMPTY
 };
 pub const OP_SPACE_OR: BinaryOp = BinaryOp {
     name: " or",
     prec: 3,
     apply: apply_or,
     can_apply: can_apply_space_or,
-    ..BinaryOp::OP_EMPTY
+    ..BinaryOp::EMPTY
 };
 pub const OP_OR_SPACE: BinaryOp = BinaryOp {
     name: "or ",
     prec: 3,
     apply: apply_or,
     can_apply: can_apply_or_space,
-    ..BinaryOp::OP_EMPTY
+    ..BinaryOp::EMPTY
 };
 pub const OP_SPACE_OR_SPACE: BinaryOp = BinaryOp {
     name: " or ",
     prec: 3,
     apply: apply_or,
     can_apply: can_apply_space_or_space,
-    ..BinaryOp::OP_EMPTY
+    ..BinaryOp::EMPTY
 };
 pub const OP_LT: BinaryOp = BinaryOp {
     name: "<",
     prec: 5,
     apply: apply_lt,
-    ..BinaryOp::OP_EMPTY
+    ..BinaryOp::EMPTY
 };
 pub const OP_LE: BinaryOp = BinaryOp {
     name: "<=",
     prec: 5,
     apply: apply_le,
-    ..BinaryOp::OP_EMPTY
+    ..BinaryOp::EMPTY
 };
 pub const OP_GT: BinaryOp = BinaryOp {
     name: ">",
     prec: 5,
     apply: apply_gt,
-    ..BinaryOp::OP_EMPTY
+    ..BinaryOp::EMPTY
 };
 pub const OP_GE: BinaryOp = BinaryOp {
     name: ">=",
     prec: 5,
     apply: apply_ge,
-    ..BinaryOp::OP_EMPTY
+    ..BinaryOp::EMPTY
 };
 pub const OP_EQ: BinaryOp = BinaryOp {
     name: "==",
     prec: 5,
     apply: apply_eq,
     commutative: true,
-    ..BinaryOp::OP_EMPTY
+    ..BinaryOp::EMPTY
 };
 pub const OP_NE: BinaryOp = BinaryOp {
     name: "!=",
     prec: 5,
     apply: apply_ne,
     commutative: true,
-    ..BinaryOp::OP_EMPTY
+    ..BinaryOp::EMPTY
 };
 pub const OP_BIT_OR: BinaryOp = BinaryOp {
     name: "|",
     prec: 6,
     apply: apply_bit_or,
     commutative: true,
-    ..BinaryOp::OP_EMPTY
+    ..BinaryOp::EMPTY
 };
 pub const OP_BIT_XOR: BinaryOp = BinaryOp {
     name: "^",
     prec: 7,
     apply: apply_bit_xor,
     commutative: true,
-    ..BinaryOp::OP_EMPTY
+    ..BinaryOp::EMPTY
 };
 pub const OP_BIT_AND: BinaryOp = BinaryOp {
     name: "&",
     prec: 8,
     apply: apply_bit_and,
     commutative: true,
-    ..BinaryOp::OP_EMPTY
+    ..BinaryOp::EMPTY
 };
 pub const OP_BIT_SHL: BinaryOp = BinaryOp {
     name: "<<",
     prec: 9,
     apply: apply_bit_shl,
     commutative: false,
-    ..BinaryOp::OP_EMPTY
+    ..BinaryOp::EMPTY
 };
 pub const OP_BIT_SHL_WRAP: BinaryOp = BinaryOp {
     name: "<<",
     prec: 9,
     apply: apply_bit_shl_wrap,
-    ..BinaryOp::OP_EMPTY
+    ..BinaryOp::EMPTY
 };
 pub const OP_BIT_SHR: BinaryOp = BinaryOp {
     name: ">>",
     prec: 9,
     apply: apply_bit_shr,
-    ..BinaryOp::OP_EMPTY
+    ..BinaryOp::EMPTY
 };
 pub const OP_BIT_SHR_WRAP: BinaryOp = BinaryOp {
     name: ">>",
     prec: 9,
     apply: apply_bit_shr_wrap,
-    ..BinaryOp::OP_EMPTY
+    ..BinaryOp::EMPTY
 };
 pub const OP_ADD: BinaryOp = BinaryOp {
     name: "+",
     prec: 10,
     apply: apply_add,
     commutative: true,
-    ..BinaryOp::OP_EMPTY
+    ..BinaryOp::EMPTY
 };
 pub const OP_SUB: BinaryOp = BinaryOp {
     name: "-",
     prec: 10,
     apply: apply_sub,
-    ..BinaryOp::OP_EMPTY
+    ..BinaryOp::EMPTY
 };
 pub const OP_MUL: BinaryOp = BinaryOp {
     name: "*",
     prec: 11,
     apply: apply_mul,
     commutative: true,
-    ..BinaryOp::OP_EMPTY
+    ..BinaryOp::EMPTY
 };
 pub const OP_MOD_FLOOR: BinaryOp = BinaryOp {
     name: "%",
     prec: 11,
     apply: apply_mod_floor,
-    ..BinaryOp::OP_EMPTY
+    ..BinaryOp::EMPTY
 };
 pub const OP_MOD_TRUNC: BinaryOp = BinaryOp {
     name: "%",
     prec: 11,
     apply: apply_mod_trunc,
-    ..BinaryOp::OP_EMPTY
+    ..BinaryOp::EMPTY
 };
 pub const OP_DIV_FLOOR: BinaryOp = BinaryOp {
     name: "//",
     prec: 11,
     apply: apply_div_floor,
-    ..BinaryOp::OP_EMPTY
+    ..BinaryOp::EMPTY
 };
 pub const OP_DIV_TRUNC: BinaryOp = BinaryOp {
     name: "/",
     prec: 11,
     apply: apply_div_trunc,
-    ..BinaryOp::OP_EMPTY
+    ..BinaryOp::EMPTY
 };
 pub const OP_GCD: BinaryOp = BinaryOp {
     name: "V",
     prec: 11,
     apply: apply_gcd,
     commutative: true,
-    ..BinaryOp::OP_EMPTY
+    ..BinaryOp::EMPTY
 };
 pub const OP_EXP: BinaryOp = BinaryOp {
     name: "**",
     prec: 13,
     apply: apply_exp,
     right_assoc: true,
-    ..BinaryOp::OP_EMPTY
+    ..BinaryOp::EMPTY
 };
 pub const OP_BIT_NEG: UnaryOp = UnaryOp {
     name: "~",
@@ -415,36 +415,39 @@ pub const OP_NEG: UnaryOp = UnaryOp {
     can_apply: can_apply_unary_always,
 };
 
-// All operators: [..Unary, ..Binary, Parens, Literal, Variable]
+// All operators: [..Binary, ..Unary, Parens, Literal, Variable]
 pub const NUM_OPERATORS: usize = UNARY_OPERATORS.len() + BINARY_OPERATORS.len() + 3;
 pub const OP_INDEX_PARENS: OpIndex = OpIndex::new(0xFD);
 pub const OP_INDEX_LITERAL: OpIndex = OpIndex::new(0xFE);
 pub const OP_INDEX_VARIABLE: OpIndex = OpIndex::new(0xFF);
 
-const fn gen_binary_index_table() -> [OpIndex; BINARY_OPERATORS.len()] {
-    let mut table = [OpIndex::new(0); BINARY_OPERATORS.len()];
+const fn gen_index_tables() -> (
+    [OpIndex; BINARY_OPERATORS.len()],
+    [OpIndex; UNARY_OPERATORS.len()],
+) {
+    let mut binary_table = [OpIndex::new(0); BINARY_OPERATORS.len()];
+    let mut unary_table = [OpIndex::new(0); UNARY_OPERATORS.len()];
     let mut cnt = [0; 16];
+
     let mut i: usize = 0;
     while i < BINARY_OPERATORS.len() {
         let prec = BINARY_OPERATORS[i].prec;
-        table[i] = OpIndex(prec << 4 | cnt[prec as usize]);
+        assert!(prec < 16 && cnt[prec as usize] < 16);
+        binary_table[i] = OpIndex(prec << 4 | cnt[prec as usize]);
         cnt[prec as usize] += 1;
         i += 1;
     }
-    table
-}
 
-const fn gen_unary_index_table() -> [OpIndex; UNARY_OPERATORS.len()] {
-    let mut table = [OpIndex::new(0); UNARY_OPERATORS.len()];
-    let mut cnt = [0; 16];
     let mut i: usize = 0;
     while i < UNARY_OPERATORS.len() {
         let prec = UNARY_OPERATORS[i].prec;
-        table[i] = OpIndex(prec << 4 | cnt[prec as usize]);
+        assert!(prec < 16 && cnt[prec as usize] < 16);
+        unary_table[i] = OpIndex(prec << 4 | cnt[prec as usize]);
         cnt[prec as usize] += 1;
         i += 1;
     }
-    table
+
+    (binary_table, unary_table)
 }
 
 const fn gen_op_name_table() -> [&'static str; 256] {
@@ -463,6 +466,6 @@ const fn gen_op_name_table() -> [&'static str; 256] {
     table
 }
 
-pub const OP_BINARY_INDEX_TABLE: [OpIndex; BINARY_OPERATORS.len()] = gen_binary_index_table();
-pub const OP_UNARY_INDEX_TABLE: [OpIndex; UNARY_OPERATORS.len()] = gen_unary_index_table();
+pub const OP_BINARY_INDEX_TABLE: [OpIndex; BINARY_OPERATORS.len()] = gen_index_tables().0;
+pub const OP_UNARY_INDEX_TABLE: [OpIndex; UNARY_OPERATORS.len()] = gen_index_tables().1;
 pub const OP_NAME_TABLE: [&'static str; 256] = gen_op_name_table();

--- a/src/params.rs
+++ b/src/params.rs
@@ -44,7 +44,7 @@ pub const LITERALS: &[Num] = &[
     27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40,
 ];
 /// If not 0, include all numbers in 1..=MAX_LITERAL in addition to LITERALS.
-pub const MAX_LITERAL: Num = 4;
+pub const MAX_LITERAL: Num = 0;
 
 #[rustfmt::skip]
 pub const BINARY_OPERATORS: &[BinaryOp] = &[

--- a/src/params.rs
+++ b/src/params.rs
@@ -72,7 +72,7 @@ pub const BINARY_OPERATORS: &[BinaryOp] = &[
     OP_DIV_FLOOR,
     // OP_MOD_TRUNC,
     // OP_DIV_TRUNC,
-    OP_GCD,
+    // OP_GCD,
     OP_EXP,
 ];
 


### PR DESCRIPTION
~5% performance gain by storing the precedence in the upper bits of OpIndex, so that `prec()` calls become fast.