### PR TITLE
support 0 length binary operator

### DIFF
--- a/src/operator.rs
+++ b/src/operator.rs
@@ -503,7 +503,9 @@ const fn gen_index_tables() -> (
     (binary_table, unary_table)
 }
 
-const fn gen_op_name_table() -> [&'static str; 256] {
+pub const OP_BINARY_INDEX_TABLE: [OpIndex; BINARY_OPERATORS.len()] = gen_index_tables().0;
+pub const OP_UNARY_INDEX_TABLE: [OpIndex; UNARY_OPERATORS.len()] = gen_index_tables().1;
+pub const OP_NAME_TABLE: [&'static str; 256] = {
     let mut table = [""; 256];
     let mut i: usize = 0;
     while i < OP_BINARY_INDEX_TABLE.len() {
@@ -517,8 +519,15 @@ const fn gen_op_name_table() -> [&'static str; 256] {
     }
     table[OP_INDEX_PARENS.as_index()] = "(";
     table
-}
-
-pub const OP_BINARY_INDEX_TABLE: [OpIndex; BINARY_OPERATORS.len()] = gen_index_tables().0;
-pub const OP_UNARY_INDEX_TABLE: [OpIndex; UNARY_OPERATORS.len()] = gen_index_tables().1;
-pub const OP_NAME_TABLE: [&'static str; 256] = gen_op_name_table();
+};
+pub const MIN_BINARY_OP_LEN: usize = {
+    let mut min_len = usize::MAX;
+    let mut i = 0;
+    while i < OP_BINARY_INDEX_TABLE.len() {
+        if BINARY_OPERATORS[i].name.len() < min_len {
+            min_len = BINARY_OPERATORS[i].name.len();
+        }
+        i += 1;
+    }
+    min_len
+};


### PR DESCRIPTION
`MIN_BINARY_OP_LEN` is introduced to avoid performance regression when no 0 length binary operators are specified