### PR TITLE
Introduce Match trait

### DIFF
--- a/src/matcher.rs
+++ b/src/matcher.rs
@@ -1,0 +1,46 @@
+use crate::params::{Num, GOAL};
+use crate::{expr::Expr, operator::OpIndex, vec::Vector};
+
+/// The Match trait provides default implementation for a simple matcher.
+/// A custom matcher in params.rs can override any constants or methods.
+pub trait Match: Sized {
+    /// Match leaf expressions 1 output at a time to avoid unnecessary
+    /// precalculations.
+    const MATCH_1BY1: bool = true;
+
+    fn new() -> Self;
+
+    fn match_one(&mut self, index: usize, output: Num) -> bool {
+        output == GOAL[index]
+    }
+
+    // Will be called after match_one returns true for all outputs
+    fn match_final(self, _el: Option<&Expr>, _er: &Expr, _op: OpIndex) -> bool {
+        true
+    }
+
+    fn match_all(expr: &Expr) -> bool {
+        let mut matcher = Self::new();
+        expr.output
+            .iter()
+            .enumerate()
+            .all(|(i, &o)| matcher.match_one(i, o))
+            && matcher.match_final(
+                expr.left.map(|e| unsafe { e.as_ref() }),
+                unsafe { expr.right.unwrap().as_ref() },
+                expr.op_idx,
+            )
+    }
+
+    fn output_has_conflict(output: &Vector) -> bool {
+        let mut mp = hashbrown::HashMap::new();
+        for i in 0..GOAL.len() {
+            if let Some(old) = mp.insert(output[i], GOAL[i]) {
+                if old != GOAL[i] {
+                    return true;
+                }
+            }
+        }
+        false
+    }
+}

--- a/src/operator.rs
+++ b/src/operator.rs
@@ -1,3 +1,5 @@
+#![allow(dead_code)]
+
 use std::fmt::Display;
 
 use crate::{

--- a/src/params.rs
+++ b/src/params.rs
@@ -1,4 +1,4 @@
-use crate::{expr::Expr, operator::*};
+use crate::{matcher::Match, operator::*};
 
 pub type Num = i32;
 
@@ -18,38 +18,22 @@ pub const INPUTS: &[Input] = &[Input {
 
 pub struct Matcher {}
 
-impl Matcher {
-    pub fn new() -> Self {
+impl Match for Matcher {
+    fn new() -> Self {
         Self {}
     }
 
-    pub fn match_one(&mut self, index: usize, output: Num) -> bool {
+    // Override the default match_one, other methods in the Match trait can be
+    // overridden as well.
+    fn match_one(&mut self, index: usize, output: Num) -> bool {
         output == GOAL[index]
-    }
-
-    // Will be called after match_one returns true for all outputs
-    pub fn match_final(self, _el: Option<&Expr>, _er: &Expr, _op: OpIndex) -> bool {
-        true
-    }
-
-    pub fn match_all(expr: &Expr) -> bool {
-        let mut matcher = Self::new();
-        expr.output
-            .iter()
-            .enumerate()
-            .all(|(i, &o)| matcher.match_one(i, o))
-            && matcher.match_final(
-                expr.left.map(|e| unsafe { e.as_ref() }),
-                unsafe { expr.right.unwrap().as_ref() },
-                expr.op_idx,
-            )
     }
 }
 
 pub const GOAL: &[Num] = &[1, -1, 0, 0];
 
-pub const MAX_LENGTH: usize = 14;
-pub const MAX_CACHE_LENGTH: usize = 10;
+pub const MAX_LENGTH: usize = 9;
+pub const MAX_CACHE_LENGTH: usize = 5;
 pub const MIN_MULTITHREAD_LENGTH: usize = MAX_CACHE_LENGTH + 1;
 pub const LITERALS: &[Num] = &[
     1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26,
@@ -102,9 +86,6 @@ pub const UNARY_OPERATORS: &[UnaryOp] = &[
     OP_NEG,
     // OP_NOT,
 ];
-
-/// Match leaf expressions 1 output at a time to avoid unnecessary precalculations
-pub const MATCH_1BY1: bool = true;
 
 /// If set, e.g. to `Some(-159236)`, this arbitrary number is chosen to represent errors.
 /// That is, pysearch will pretend 1/0 = -159236, and -159236 * 2 = -159236, and so on.


### PR DESCRIPTION
Provides default implementation and allows params to override any methods. Moved the output conflict check into it since custom matcher often need different conflict rules.