### PR TITLE
More accurate log

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -461,7 +461,7 @@ fn main() {
         let count = cache[n].len();
         total_count += count;
         let time = layer_start.elapsed();
-        println!("Explored {count} expressions in {time:?}");
+        println!("Cached {count} expressions in {time:?}");
         let total_time = start.elapsed();
         println!("Total: {total_count} expressions in {total_time:?}\n");
         if ENABLE_INVERSE_SEARCH && n == MAX_CACHE_LENGTH {


### PR DESCRIPTION
The printed number is actually the number of cached expressions, in cache level we explore more expressions but only keep ones that aren't duplicate, in DFS level we explore lots of expressions but doesn't cache any.